### PR TITLE
Fall Back to Entry id if Entry Links Do Not Exist

### DIFF
--- a/lib/post.ml
+++ b/lib/post.ml
@@ -163,7 +163,13 @@ let post_of_atom ~(feed : Feed.t) (e : Syndic.Atom.entry) =
         (List.find (fun l -> l.Syndic.Atom.rel = Syndic.Atom.Alternate) e.links)
           .href
     with Not_found -> (
-      match e.links with l :: _ -> Some l.href | [] -> None)
+      match e.links with
+      | l :: _ -> Some l.href
+      | [] -> (
+          match Uri.scheme e.id with
+          | Some "http" -> Some e.id
+          | Some "https" -> Some e.id
+          | _ -> None))
   in
   let date =
     match e.published with Some _ -> e.published | None -> Some e.updated


### PR DESCRIPTION
It is legal for an Atom feed to not have `links`.

In this case, it appears sensible to rely on the value provided by the `id` tag.