### PR TITLE
Replace ocamlnet HTML parser with Lambda Soup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ RSS2 and Atom feed aggregator for OCaml
 - Supports pagination and generating well-formed html prefix snippets.
 - Support for generating aggregate feeds.
 - Sorts the posts from most recent to oldest.
-- Depends on ocamlnet for html parsing.
+- Depends on Lambda Soup for html parsing.
 
 ## Installation
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name river)
  (public_name river)
- (libraries cohttp cohttp-lwt cohttp-lwt-unix syndic netstring lambdasoup))
+ (libraries cohttp cohttp-lwt cohttp-lwt-unix str syndic lambdasoup))

--- a/lib/river.ml
+++ b/lib/river.ml
@@ -29,7 +29,7 @@ let date post = post.Post.date
 let feed post = post.Post.feed
 let author post = post.Post.author
 let email post = post.Post.email
-let content post = Post.string_of_html post.Post.content
+let content post = Soup.to_string post.Post.content
 
 let meta_description post =
   match Post.fetch_link post with

--- a/river.opam
+++ b/river.opam
@@ -17,7 +17,6 @@ depends: [
   "cohttp-lwt-unix" {>= "5.0.0"}
   "ptime"
   "lwt"
-  "ocamlnet"
   "lambdasoup"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
As suggested in https://github.com/ocaml/ocaml.org/pull/2609#issuecomment-2247139726.

It looks like Lambda Soup was already being used in some of the newer code in `meta.ml` by @tmattio. This PR also replaces usage of the `Nethtml` parser from ocamlnet by Lambda Soup.

I tested this by running `example/aggregate_feeds.ml` and it seems to still give plausible output. Are there other tests I should run?