### PR TITLE
Expose timeout and user-agent in public API

### DIFF
--- a/lib/feed.ml
+++ b/lib/feed.ml
@@ -28,9 +28,9 @@ let classify_feed ~xmlbase (xml : string) =
     try Rss2 (Syndic.Rss2.parse ~xmlbase (Xmlm.make_input (`String (0, xml))))
     with Syndic.Rss2.Error.Error _ -> failwith "Neither Atom nor RSS2 feed")
 
-let fetch (source : source) =
+let fetch ?timeout ?user_agent (source : source) =
   let xmlbase = Uri.of_string @@ source.url in
-  let response = Http.get source.url in
+  let response = Http.get ?timeout ?user_agent source.url in
   let content = classify_feed ~xmlbase response in
   let title =
     match content with

--- a/lib/http.ml
+++ b/lib/http.ml
@@ -34,34 +34,42 @@ let get_location_exn headers =
   | Some x -> x
   | None -> raise @@ Status_unhandled "Location HTTP header not found"
 
-let rec get_uri uri = function
+let rec get_uri ~headers ~timeout uri = function
   | 0 -> raise (Status_unhandled "Too many redirects")
   | n ->
       let main =
-        Cohttp_lwt_unix.Client.get uri >>= fun (resp, body) ->
+        Cohttp_lwt_unix.Client.get ~headers uri >>= fun (resp, body) ->
         match resp.status with
         | `OK -> Cohttp_lwt.Body.to_string body
         | `Found | `See_other | `Moved_permanently | `Temporary_redirect
         | `Permanent_redirect -> (
             let l = Uri.of_string @@ get_location_exn resp.headers in
             match Uri.host l with
-            | Some _ -> get_uri l (n - 1)
+            | Some _ -> get_uri ~headers ~timeout l (n - 1)
             | None ->
                 let host = Uri.host uri in
                 let scheme = Uri.scheme uri in
                 let new_uri = Uri.with_scheme (Uri.with_host l host) scheme in
-                get_uri new_uri (n - 1))
+                get_uri ~headers ~timeout new_uri (n - 1))
         | _ -> raise @@ Status_unhandled (string_of_status resp.status)
       in
       let timeout =
-        Lwt_unix.sleep (float_of_int 3) >>= fun () -> Lwt.fail Timeout
+        Lwt_unix.sleep timeout >>= fun () -> Lwt.fail Timeout
       in
       Lwt.pick [ main; timeout ]
 
-let get url =
+let get ?(timeout = 3.) ?user_agent url =
   eprintf "Downloading %s ... %!" url;
+  let headers =
+    match user_agent with
+    | None -> Header.init ()
+    | Some ua -> Header.init_with "User-Agent" ua
+  in
   try
-    let data = Lwt_main.run @@ get_uri (Uri.of_string url) max_num_redirects in
+    let data =
+      Lwt_main.run
+      @@ get_uri ~headers ~timeout (Uri.of_string url) max_num_redirects
+    in
     eprintf "done %!\n";
     data
   with

--- a/lib/http.mli
+++ b/lib/http.mli
@@ -18,8 +18,13 @@
 exception Status_unhandled of string
 exception Timeout
 
-val get : string -> string
-(** [get uri] returns the body of the response of the HTTP GET request on [uri].
+val get : ?timeout:float -> ?user_agent:string -> string -> string
+(** [get ?timeout ?user_agent uri] returns the body of the response of the HTTP
+    GET request on [uri].
+
+    @param timeout Connection timeout in seconds. Default: [3.].
+    @param user_agent Value sent in the [User-Agent] HTTP header. Omitted by
+      default.
 
     If the answer of is a redirection, it will follow the redirections up to 5
     redirects.

--- a/lib/post.ml
+++ b/lib/post.ml
@@ -200,14 +200,14 @@ let get_posts ?n ?(ofs = 0) planet_feeds =
   match n with None -> posts | Some n -> take n posts
 
 (* Fetch the link response and cache it. *)
-let fetch_link t =
+let fetch_link ?timeout ?user_agent t =
   match (t.link, t.link_response) with
   | None, _ -> None
   | Some _, Some (Ok x) -> Some x
   | Some _, Some (Error _) -> None
   | Some link, None -> (
       try
-        let response = Http.get (Uri.to_string link) in
+        let response = Http.get ?timeout ?user_agent (Uri.to_string link) in
         t.link_response <- Some (Ok response);
         Some response
       with _exn ->

--- a/lib/river.ml
+++ b/lib/river.ml
@@ -19,7 +19,7 @@ type source = Feed.source = { name : string; url : string }
 type feed = Feed.t
 type post = Post.t
 
-let fetch = Feed.fetch
+let fetch ?timeout ?user_agent source = Feed.fetch ?timeout ?user_agent source
 let name feed = feed.Feed.name
 let url feed = feed.Feed.url
 let posts feeds = Post.get_posts feeds
@@ -31,13 +31,13 @@ let author post = post.Post.author
 let email post = post.Post.email
 let content post = Soup.to_string post.Post.content
 
-let meta_description post =
-  match Post.fetch_link post with
+let meta_description ?timeout ?user_agent post =
+  match Post.fetch_link ?timeout ?user_agent post with
   | None -> None
   | Some response -> Meta.description response
 
-let seo_image post =
-  match Post.fetch_link post with
+let seo_image ?timeout ?user_agent post =
+  match Post.fetch_link ?timeout ?user_agent post with
   | None -> None
   | Some response -> Meta.preview_image response
 

--- a/lib/river.mli
+++ b/lib/river.mli
@@ -21,8 +21,13 @@ type source = { name : string; url : string }
 type feed
 type post
 
-val fetch : source -> feed
-(** [fetch source] returns an Atom or RSS feed from a source. *)
+val fetch : ?timeout:float -> ?user_agent:string -> source -> feed
+(** [fetch ?timeout ?user_agent source] returns an Atom or RSS feed from a
+    source.
+
+    @param timeout Connection timeout in seconds. Default: [3.].
+    @param user_agent Value sent in the [User-Agent] HTTP header. Omitted by
+      default. *)
 
 val name : feed -> string
 (** [name feed] is the name of the feed source passed to [fetch]. *)
@@ -54,16 +59,26 @@ val email : post -> string
 val content : post -> string
 (** [content post] is the content of the post. *)
 
-val meta_description : post -> string option
-(** [meta_description post] is the meta description of the post on the origin
-    site.
+val meta_description :
+  ?timeout:float -> ?user_agent:string -> post -> string option
+(** [meta_description ?timeout ?user_agent post] is the meta description of the
+    post on the origin site.
+
+    @param timeout Connection timeout in seconds. Default: [3.].
+    @param user_agent Value sent in the [User-Agent] HTTP header. Omitted by
+      default.
 
     To get the meta description, we make get the content of [link post] and look
     for an HTML meta tag with the name "description" or "og:description".*)
 
-val seo_image : post -> string option
-(** [seo_image post] is the image to be used by social networks and links to the
-    post.
+val seo_image :
+  ?timeout:float -> ?user_agent:string -> post -> string option
+(** [seo_image ?timeout ?user_agent post] is the image to be used by social
+    networks and links to the post.
+
+    @param timeout Connection timeout in seconds. Default: [3.].
+    @param user_agent Value sent in the [User-Agent] HTTP header. Omitted by
+      default.
 
     To get the seo image, we make get the content of [link post] and look for an
     HTML meta tag with the name "og:image" or "twitter:image". *)


### PR DESCRIPTION
## Summary

- Thread optional `?timeout` (float, seconds) and `?user_agent` (string) parameters through the call chain from the public API (`River.fetch`, `River.meta_description`, `River.seo_image`) down to `Http.get`
- Replace the hardcoded 3-second timeout with a configurable parameter (default unchanged)
- Add `User-Agent` HTTP header support (omitted by default, preserving current behavior)

## Test plan

- [x] `dune build` succeeds
- [x] `dune runtest` passes
- [ ] Verify backward compatibility: existing callers without the new params compile unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)